### PR TITLE
Add reservation retrieval and QR scanning

### DIFF
--- a/apps/api/src/api.rs
+++ b/apps/api/src/api.rs
@@ -86,12 +86,18 @@ pub enum ReservationStatus {
 }
 
 #[derive(Debug, Serialize)]
+pub struct ReservationTokenResponse {
+    pub token: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct RetrieveReservationResponse {
     pub reservation_id: Uuid,
     pub user_name: String,
     pub user_email: String,
     pub status: ReservationStatus,
-    pub reservation_tokens: Vec<String>,
+    pub reservation_tokens: Vec<ReservationTokenResponse>,
     #[serde(with = "time::serde::iso8601")]
     pub created_at: OffsetDateTime,
     #[serde(with = "time::serde::iso8601")]
@@ -99,6 +105,12 @@ pub struct RetrieveReservationResponse {
     #[serde(with = "time::serde::iso8601::option")]
     pub verified_at: Option<OffsetDateTime>,
     pub event: RetrieveReservationEventResponse,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScanTokenResponse {
+    pub token: String,
+    pub status: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -64,6 +64,12 @@ impl IntoResponse for AppError {
             AppError::Database(crate::db::DatabaseError::ReservationNotFound) => {
                 (StatusCode::NOT_FOUND, "Reservation not found".to_string())
             }
+            AppError::Database(crate::db::DatabaseError::TokenInvalid) => {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Reservation token not found or already used".to_string(),
+                )
+            }
             AppError::Database(_) => {
                 // Log the actual error but don't expose internal details to the client
                 eprintln!("Database error: {}", self);

--- a/apps/web-ui/src/Router.tsx
+++ b/apps/web-ui/src/Router.tsx
@@ -14,6 +14,8 @@ import EventViewer from "./_1_EventViewer";
 import Header from "./Header";
 import ReservationConfirmation from "./_3_ReservationConfirmation";
 import VerifyEmail from "./_4_VerifyEmail";
+import RetrieveReservation from "./_5_RetrieveReservation";
+import ScanReservation from "./_6_ScanReservation";
 
 const rootRoute = createRootRoute({
 	component: () => (
@@ -92,24 +94,47 @@ const reservationConfirmationRoute = createRoute({
 });
 
 const verifyEmailRoute = createRoute({
-	getParentRoute: () => rootRoute,
-	path: "/verify/$token",
-	component: function VerifyEmailContainer() {
-		return (
-			<>
-				<Header />
-				<VerifyEmail />
-			</>
-		);
-	},
+        getParentRoute: () => rootRoute,
+        path: "/verify/$token",
+        component: function VerifyEmailContainer() {
+                return (
+                        <>
+                                <Header />
+                                <VerifyEmail />
+                        </>
+                );
+        },
+});
+
+const retrieveReservationRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: "/retrieve/$reservationId",
+        component: function RetrieveReservationContainer() {
+                return (
+                        <>
+                                <Header />
+                                <RetrieveReservation />
+                        </>
+                );
+        },
+});
+
+const scanReservationRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: "/scan/$token",
+        component: function ScanReservationContainer() {
+                return <ScanReservation />;
+        },
 });
 
 const routeTree = rootRoute.addChildren([
-	indexRoute,
-	eventViewerRoute,
-	eventReserveRoute,
-	reservationConfirmationRoute,
-	verifyEmailRoute,
+        indexRoute,
+        eventViewerRoute,
+        eventReserveRoute,
+        reservationConfirmationRoute,
+        verifyEmailRoute,
+        retrieveReservationRoute,
+        scanReservationRoute,
 ]);
 
 export const router = createRouter({

--- a/apps/web-ui/src/_5_RetrieveReservation.tsx
+++ b/apps/web-ui/src/_5_RetrieveReservation.tsx
@@ -1,0 +1,50 @@
+import { useParams } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+
+const RetrieveReservation: React.FC = () => {
+  const { reservationId } = useParams({ from: "/retrieve/$reservationId" });
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["retrieve-reservation", reservationId],
+    queryFn: () =>
+      fetch(`http://localhost:8000/retrieve/${reservationId}`).then((res) =>
+        res.json(),
+      ),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">Loading reservation...</div>
+    );
+  }
+
+  if (error || data?.error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">Error retrieving reservation</div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 to-indigo-100 flex items-center justify-center">
+      <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">Your Reservation</h1>
+        <p className="mb-4">{data.event.name}</p>
+        <div className="space-y-4">
+          {data.reservation_tokens.map((token: { token: string; status: string }) => (
+            <div key={token.token} className="flex flex-col items-center">
+              <a href={`/scan/${token.token}`}>
+                <img
+                  src={`https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${encodeURIComponent(window.location.origin + '/scan/' + token.token)}`}
+                  alt="Reservation QR"
+                />
+              </a>
+              <p className="mt-2 text-sm text-gray-600">Status: {token.status}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RetrieveReservation;

--- a/apps/web-ui/src/_6_ScanReservation.tsx
+++ b/apps/web-ui/src/_6_ScanReservation.tsx
@@ -1,0 +1,31 @@
+import { useParams } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+
+const ScanReservation: React.FC = () => {
+  const { token } = useParams({ from: "/scan/$token" });
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["scan-token", token],
+    queryFn: () =>
+      fetch(`http://localhost:8000/scan/${token}`).then((res) => res.json()),
+  });
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-yellow-50 to-orange-100 flex items-center justify-center">
+      <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
+        {isLoading ? (
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">Scanning...</h1>
+        ) : error || data?.error ? (
+          <h1 className="text-2xl font-bold text-red-600 mb-4">Invalid or used token</h1>
+        ) : (
+          <>
+            <h1 className="text-2xl font-bold text-gray-900 mb-4">Checked In!</h1>
+            <p className="text-gray-600">Token {data.token} marked as {data.status}</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ScanReservation;


### PR DESCRIPTION
## Summary
- add API structs and endpoints to retrieve reservations and scan QR tokens
- support marking tokens as used in database with new error mapping
- build frontend pages to view reservation QR codes and scan them for check-in

## Testing
- `cargo test` *(fails: config::tests::test_config_from_env_with_custom_values, config::tests::test_config_from_env_with_defaults, db::tests::test_database_operations)*
- `npm test` *(fails: Missing `packageManager` field in package.json)*
- `npm test` in `apps/web-ui` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0eb9ad9b0832eadc8f7beb6c72e36